### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .

--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,8 @@
 	"build-depends" : [],
 	"depends" : [],
 	"test-depends" : [
-		"Test"
+		"Test",
+		"Test::META"
 	],
 	"provides" : {
 		"CompUnit::Search" : "lib/CompUnit/Search.pm6"


### PR DESCRIPTION
This allows the project to be automatically built and tested with the latest version of Perl6 on the [Travis-CI](https://travis-ci.org) continuous integration service.

This PR also updates the list of test dependencies, since `Test::META` is required to run the `01-meta.t` tests.
